### PR TITLE
fix(sidekick): manter favoritos visíveis e preservar lista no set-prompts

### DIFF
--- a/app/(main)/prompts/hooks/usePromptState.ts
+++ b/app/(main)/prompts/hooks/usePromptState.ts
@@ -182,13 +182,15 @@ export function usePromptState(
                 case 'set-prompts':
                     const receivedPrompts = (event.data as PromptsMessageFromParentType).payload.prompts
                     if (Array.isArray(receivedPrompts) && receivedPrompts.length > 0) {
-                        const promptsMap = new Map(prompts.map(p => [p.id, p]))
-                        const list = []
+                        const hiddenById = new Map<number, boolean | undefined>()
                         for (const p of receivedPrompts) {
-                            if (p.id != null && promptsMap.has(p.id)) {
-                                list.push({ ...promptsMap.get(p.id), is_hidden: p.is_hidden })
-                            }
+                            if (p.id != null) hiddenById.set(p.id, p.is_hidden)
                         }
+                        const list = prompts.map((p) =>
+                            hiddenById.has(p.id)
+                                ? { ...p, is_hidden: hiddenById.get(p.id) }
+                                : p
+                        )
                         setPrompts(list)
                     }
             }

--- a/app/(main)/prompts/utils/promptFilters.ts
+++ b/app/(main)/prompts/utils/promptFilters.ts
@@ -66,6 +66,9 @@ export function getPromptsSidekick(
                 p.is_hidden = calcHidden(hInstance, hAction)
             }
             if (p.is_favorite) p.is_hidden = false
+        } else if (p.is_favorite) {
+            // Non-internal favorites have no TipoDeSintese/context; keep them visible in Sidekick.
+            p.is_hidden = false
         }
 
         if (!p.is_hidden) {


### PR DESCRIPTION
## Problema
No Sidekick, nem todos os prompts favoritados ficam visíveis. Isso afeta principalmente prompts não internos (ex.: comunidade), que o usuário marca como favorito, mas depois não encontra na lista do Sidekick.

## Impacto prático para o usuário
- O usuário favorita um prompt e espera acesso rápido no Sidekick.
- Depois de certas sincronizações (`set-prompts`), parte da lista desaparece.
- Na prática, o comportamento parece inconsistente: favoritos somem, reaparecem ou não entram na lista, mesmo já estando favoritados.

## Causa raiz
Há dois pontos combinados:

1. `set-prompts` substituía indevidamente a lista local por um subconjunto
- Arquivo: `app/(main)/prompts/hooks/usePromptState.ts`
- O evento `set-prompts` recebia um payload parcial e montava `list` apenas com os itens recebidos.
- Resultado: prompts que existiam localmente, mas não vieram naquele payload, eram descartados do estado.

2. Favoritos não internos podiam continuar ocultos
- Arquivo: `app/(main)/prompts/utils/promptFilters.ts`
- A regra `if (p.is_favorite) p.is_hidden = false` estava dentro do bloco de prompts internos (`isInternalPrompt`).
- Resultado: prompts favoritados não internos podiam permanecer com `is_hidden = true` e não eram renderizados no Sidekick.

## O que foi alterado
1. Preservar a lista completa no `set-prompts`
- Em vez de substituir a coleção local por um subconjunto, o código agora:
  - cria um mapa `hiddenById` com os `id`s recebidos,
  - percorre a lista local completa,
  - atualiza apenas `is_hidden` dos prompts presentes no payload.
- Efeito: nenhum prompt some do estado por causa de payload parcial.

2. Garantir visibilidade de favoritos não internos no Sidekick
- Adicionada regra explícita para `p.is_favorite` fora do bloco de internos.
- Efeito: favorito não interno também força `is_hidden = false`.

## Por que essa solução é efetiva
- O Sidekick renderiza apenas prompts com `is_hidden === false`.
- Com as mudanças:
  - o estado local deixa de perder itens na sincronização,
  - favoritos (internos e não internos) permanecem elegíveis para renderização.
- Isso resolve o sintoma observado pelo usuário: favoritos deixam de desaparecer indevidamente.

## Escopo e risco
- Mudança localizada em 2 arquivos, sem alterar contrato de API nem estrutura de dados.
- A lógica nova é conservadora: mantém a lista existente e sincroniza apenas visibilidade por `id`.

## Validação
- Revisão de fluxo de estado + filtro de renderização do Sidekick.
- Verificação do diff e dos caminhos afetados.
- Tentativa de `npm run typecheck` no ambiente local atual falhou por problemas gerais do workspace (dependências/tipos ausentes e erros pré-existentes não relacionados a este patch).

## Arquivos alterados
- `app/(main)/prompts/hooks/usePromptState.ts`
- `app/(main)/prompts/utils/promptFilters.ts`
